### PR TITLE
fix: support more ton token

### DIFF
--- a/common/protob/messages-ton.proto
+++ b/common/protob/messages-ton.proto
@@ -53,7 +53,7 @@ message TonSignMessage {
     optional string jetton_master_address = 3;                      // Jetton master smart contract address
     optional string jetton_wallet_address = 4;                      // Jetton wallet smart contract address 
     required uint64 ton_amount = 5;                                 // TON value for gas
-    optional uint64 jetton_amount = 6;                              // jetton value (by nanojetton)
+    optional uint64 jetton_amount = 6;                              // jetton value
     optional uint64 fwd_fee = 7 [default=0];                        // toncoin is needed to transfer notification message
     optional string comment = 8;                                    // message comment
     optional bool is_raw_data = 9 [default=false];                  // raw data flag
@@ -68,6 +68,7 @@ message TonSignMessage {
     repeated string ext_destination = 18;
     repeated uint64 ext_ton_amount = 19;
     repeated string ext_payload = 20;
+    optional bytes jetton_amount_bytes = 21;                        // jetton value in bytes
 }
 
 /**

--- a/core/src/trezor/messages.py
+++ b/core/src/trezor/messages.py
@@ -8729,6 +8729,7 @@ if TYPE_CHECKING:
         ext_destination: "list[str]"
         ext_ton_amount: "list[int]"
         ext_payload: "list[str]"
+        jetton_amount_bytes: "bytes | None"
 
         def __init__(
             self,
@@ -8753,6 +8754,7 @@ if TYPE_CHECKING:
             workchain: "TonWorkChain | None" = None,
             is_bounceable: "bool | None" = None,
             is_testnet_only: "bool | None" = None,
+            jetton_amount_bytes: "bytes | None" = None,
         ) -> None:
             pass
 

--- a/python/src/trezorlib/cli/ton.py
+++ b/python/src/trezorlib/cli/ton.py
@@ -73,6 +73,7 @@ def get_address(client: "TrezorClient",
 @click.option("-jw", "--jetton_wallet_address", type=str)
 @click.option("-ta", "--ton_amount", type=int, required=True)
 @click.option("-ja", "--jetton_amount", type=int)
+@click.option("-jab", "--jetton_amount_bytes", type=str)
 @click.option("-f", "--fwd_fee", type=int)
 @click.option("-c", "--comment", type=str)
 @click.option("-r", "--is_raw_data", is_flag=True)
@@ -95,6 +96,7 @@ def sign_message(client: "TrezorClient",
                 jetton_wallet_address: str,
                 ton_amount: int,
                 jetton_amount: int,
+                jetton_amount_bytes: str,
                 fwd_fee: int,
                 mode: int,
                 seqno: int,
@@ -121,6 +123,7 @@ def sign_message(client: "TrezorClient",
                 jetton_wallet_address,
                 ton_amount,
                 jetton_amount,
+                jetton_amount_bytes,
                 fwd_fee,
                 mode,
                 seqno,

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -10823,6 +10823,7 @@ class TonSignMessage(protobuf.MessageType):
         18: protobuf.Field("ext_destination", "string", repeated=True, required=False),
         19: protobuf.Field("ext_ton_amount", "uint64", repeated=True, required=False),
         20: protobuf.Field("ext_payload", "string", repeated=True, required=False),
+        21: protobuf.Field("jetton_amount_bytes", "bytes", repeated=False, required=False),
     }
 
     def __init__(
@@ -10848,6 +10849,7 @@ class TonSignMessage(protobuf.MessageType):
         workchain: Optional["TonWorkChain"] = TonWorkChain.BASECHAIN,
         is_bounceable: Optional["bool"] = False,
         is_testnet_only: Optional["bool"] = False,
+        jetton_amount_bytes: Optional["bytes"] = None,
     ) -> None:
         self.address_n: Sequence["int"] = address_n if address_n is not None else []
         self.ext_destination: Sequence["str"] = ext_destination if ext_destination is not None else []
@@ -10869,6 +10871,7 @@ class TonSignMessage(protobuf.MessageType):
         self.workchain = workchain
         self.is_bounceable = is_bounceable
         self.is_testnet_only = is_testnet_only
+        self.jetton_amount_bytes = jetton_amount_bytes
 
 
 class TonSignedMessage(protobuf.MessageType):

--- a/python/src/trezorlib/ton.py
+++ b/python/src/trezorlib/ton.py
@@ -37,6 +37,7 @@ def sign_message(client: "TrezorClient",
                 jetton_wallet_address: str,
                 ton_amount: int,
                 jetton_amount: int,
+                jetton_amount_bytes: str,
                 fwd_fee: int,
                 mode: int,
                 seqno: int,
@@ -52,6 +53,8 @@ def sign_message(client: "TrezorClient",
                 ext_ton_amount: list[int] = None,
                 ext_payload: list[str] = None
                 ):
+    if jetton_amount_bytes is not None:
+        jetton_amount_bytes = int(jetton_amount_bytes).to_bytes((int(jetton_amount_bytes).bit_length() + 7) // 8, byteorder='big')
     return client.call(
         messages.TonSignMessage(
             address_n=n,
@@ -60,6 +63,7 @@ def sign_message(client: "TrezorClient",
             jetton_wallet_address=jetton_wallet_address,
             ton_amount=ton_amount,
             jetton_amount=jetton_amount,
+            jetton_amount_bytes=jetton_amount_bytes,
             fwd_fee=fwd_fee,
             comment=comment,
             mode=mode,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 在消息结构中添加了新的字段 `jetton_amount_bytes`，增强了交易信息的处理能力。
	- `sign_message` 命令现在支持新的选项 `jetton_amount_bytes`，用户可以更灵活地进行签名操作。

- **功能改进**
	- 更新了签名消息的逻辑，确保在缺少 `jetton_amount` 时使用默认值。
	- 增强了与 `Ton` 区块链相关的类，增加了对复杂交易场景的支持。

- **文档**
	- 更新了相关函数和类的签名，反映了新字段和参数的添加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->