### PR TITLE
feat(core): adjust the safety check strategy to only allow evm chains…

### DIFF
--- a/core/src/apps/aptos/get_address.py
+++ b/core/src/apps/aptos/get_address.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 async def get_address(
     ctx: Context, msg: AptosGetAddress, keychain: Keychain
 ) -> AptosAddress:
-    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=True)
+    await paths.validate_path(ctx, keychain, msg.address_n)
 
     node = keychain.derive(msg.address_n)
     pub_key_bytes = seed.remove_ed25519_prefix(node.public_key())

--- a/core/src/apps/aptos/sign_message.py
+++ b/core/src/apps/aptos/sign_message.py
@@ -15,7 +15,7 @@ async def sign_message(
     ctx: wire.Context, msg: AptosSignMessage, keychain: Keychain
 ) -> AptosMessageSignature:
 
-    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=True)
+    await paths.validate_path(ctx, keychain, msg.address_n)
 
     node = keychain.derive(msg.address_n)
     pub_key_bytes = seed.remove_ed25519_prefix(node.public_key())

--- a/core/src/apps/aptos/sign_tx.py
+++ b/core/src/apps/aptos/sign_tx.py
@@ -16,7 +16,7 @@ async def sign_tx(
     ctx: wire.Context, msg: AptosSignTx, keychain: Keychain
 ) -> AptosSignedTx:
 
-    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=True)
+    await paths.validate_path(ctx, keychain, msg.address_n)
 
     node = keychain.derive(msg.address_n)
     pub_key_bytes = seed.remove_ed25519_prefix(node.public_key())

--- a/core/src/apps/common/keychain.py
+++ b/core/src/apps/common/keychain.py
@@ -101,7 +101,7 @@ class Keychain:
         del self._cache
         del self.seed
 
-    def verify_path(self, path: paths.Bip32Path, force_strict: bool = False) -> None:
+    def verify_path(self, path: paths.Bip32Path, force_strict: bool = True) -> None:
         if "ed25519" in self.curve and not paths.path_is_hardened(path):
             raise wire.DataError("Non-hardened paths unsupported on Ed25519")
 
@@ -155,8 +155,8 @@ class Keychain:
             self._root_fingerprint = n.fingerprint()
         return self._root_fingerprint
 
-    def derive(self, path: paths.Bip32Path) -> bip32.HDNode:
-        self.verify_path(path)
+    def derive(self, path: paths.Bip32Path, force_strict: bool = True) -> bip32.HDNode:
+        self.verify_path(path, force_strict)
         return self._derive_with_cache(
             prefix_len=3,
             path=path,

--- a/core/src/apps/common/paths.py
+++ b/core/src/apps/common/paths.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
         def is_in_keychain(self, path: Bip32Path) -> bool:
             ...
 
-        def verify_path(self, path: Bip32Path, force_strict: bool = False) -> None:
+        def verify_path(self, path: Bip32Path, force_strict: bool = True) -> None:
             ...
 
 
@@ -353,7 +353,7 @@ async def validate_path(
     ctx: wire.Context,
     keychain: KeychainValidatorType,
     path: Bip32Path,
-    force_strict: bool = False,
+    force_strict: bool = True,
     *additional_checks: bool,
 ) -> None:
     keychain.verify_path(path, force_strict)

--- a/core/src/apps/ethereum/get_address.py
+++ b/core/src/apps/ethereum/get_address.py
@@ -21,9 +21,9 @@ if TYPE_CHECKING:
 async def get_address(
     ctx: Context, msg: EthereumGetAddress, keychain: Keychain, defs: Definitions
 ) -> EthereumAddress:
-    await paths.validate_path(ctx, keychain, msg.address_n)
+    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=False)
 
-    node = keychain.derive(msg.address_n)
+    node = keychain.derive(msg.address_n, force_strict=False)
 
     address = address_from_bytes(node.ethereum_pubkeyhash(), defs.network)
     if msg.show_display:

--- a/core/src/apps/ethereum/onekey/get_address.py
+++ b/core/src/apps/ethereum/onekey/get_address.py
@@ -20,9 +20,9 @@ if TYPE_CHECKING:
 async def get_address(
     ctx: Context, msg: EthereumGetAddress, keychain: Keychain
 ) -> EthereumAddress:
-    await paths.validate_path(ctx, keychain, msg.address_n)
+    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=False)
 
-    node = keychain.derive(msg.address_n)
+    node = keychain.derive(msg.address_n, force_strict=False)
 
     if msg.chain_id:
         network = networks.by_chain_id(msg.chain_id)

--- a/core/src/apps/ethereum/onekey/get_public_key.py
+++ b/core/src/apps/ethereum/onekey/get_public_key.py
@@ -20,8 +20,8 @@ if TYPE_CHECKING:
 async def get_public_key(
     ctx: Context, msg: EthereumGetPublicKey, keychain: Keychain
 ) -> EthereumPublicKey:
-    await paths.validate_path(ctx, keychain, msg.address_n)
-    node = keychain.derive(msg.address_n)
+    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=False)
+    node = keychain.derive(msg.address_n, force_strict=False)
 
     # we use the Bitcoin format for Ethereum xpubs
     btc = coins.by_name("Bitcoin")

--- a/core/src/apps/ethereum/onekey/sign_message.py
+++ b/core/src/apps/ethereum/onekey/sign_message.py
@@ -25,9 +25,9 @@ async def sign_message(
     ctx: Context, msg: EthereumSignMessage, keychain: Keychain
 ) -> EthereumMessageSignature:
     validate_message(msg.message)
-    await paths.validate_path(ctx, keychain, msg.address_n)
+    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=False)
 
-    node = keychain.derive(msg.address_n)
+    node = keychain.derive(msg.address_n, force_strict=False)
     address = address_from_bytes(node.ethereum_pubkeyhash())
 
     if msg.chain_id:

--- a/core/src/apps/ethereum/onekey/sign_tx.py
+++ b/core/src/apps/ethereum/onekey/sign_tx.py
@@ -46,7 +46,7 @@ async def sign_tx(
     ctx: wire.Context, msg: EthereumSignTx, keychain: Keychain
 ) -> EthereumTxRequest:
     check(msg)
-    await paths.validate_path(ctx, keychain, msg.address_n)
+    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=False)
 
     # Handle ERC20s
     token, address_bytes, recipient, value = await handle_erc20(ctx, msg)
@@ -85,7 +85,7 @@ async def sign_tx(
         if token is None and token_id is None and msg.data_length > 0:
             has_raw_data = True
             # await require_confirm_data(ctx, msg.data_initial_chunk, data_total)
-        node = keychain.derive(msg.address_n)
+        node = keychain.derive(msg.address_n, force_strict=False)
         recipient_str = address_from_bytes(recipient, network)
         from_str = address_from_bytes(from_addr or node.ethereum_pubkeyhash(), network)
         await require_confirm_fee(
@@ -254,7 +254,7 @@ async def send_request_chunk(ctx: wire.Context, data_left: int) -> EthereumTxAck
 def sign_digest(
     msg: EthereumSignTx, keychain: Keychain, digest: bytes
 ) -> EthereumTxRequest:
-    node = keychain.derive(msg.address_n)
+    node = keychain.derive(msg.address_n, force_strict=False)
     signature = secp256k1.sign(
         node.private_key(), digest, False, secp256k1.CANONICAL_SIG_ETHEREUM
     )

--- a/core/src/apps/ethereum/onekey/sign_tx_eip1559.py
+++ b/core/src/apps/ethereum/onekey/sign_tx_eip1559.py
@@ -68,7 +68,7 @@ async def sign_tx_eip1559(
 ) -> EthereumTxRequest:
     check(msg)
 
-    await paths.validate_path(ctx, keychain, msg.address_n)
+    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=False)
 
     # Handle ERC20s
     token, address_bytes, recipient, value = await handle_erc20(ctx, msg)
@@ -105,7 +105,7 @@ async def sign_tx_eip1559(
         if token is None and token_id is None and msg.data_length > 0:
             has_raw_data = True
             # await require_confirm_data(ctx, msg.data_initial_chunk, data_total)
-        node = keychain.derive(msg.address_n)
+        node = keychain.derive(msg.address_n, force_strict=False)
 
         recipient_str = address_from_bytes(recipient, network)
         from_str = address_from_bytes(from_addr or node.ethereum_pubkeyhash(), network)
@@ -197,7 +197,7 @@ def get_total_length(msg: EthereumSignTxEIP1559, data_total: int) -> int:
 def sign_digest(
     msg: EthereumSignTxEIP1559, keychain: Keychain, digest: bytes
 ) -> EthereumTxRequest:
-    node = keychain.derive(msg.address_n)
+    node = keychain.derive(msg.address_n, force_strict=False)
     signature = secp256k1.sign(
         node.private_key(), digest, False, secp256k1.CANONICAL_SIG_ETHEREUM
     )

--- a/core/src/apps/ethereum/onekey/sign_typed_data.py
+++ b/core/src/apps/ethereum/onekey/sign_typed_data.py
@@ -47,7 +47,7 @@ MAX_VALUE_BYTE_SIZE = 1536  # 1.5 KB
 async def sign_typed_data(
     ctx: Context, msg: EthereumSignTypedData, keychain: Keychain
 ) -> EthereumTypedDataSignature:
-    await paths.validate_path(ctx, keychain, msg.address_n)
+    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=False)
 
     if msg.chain_id:
         network = networks.by_chain_id(msg.chain_id)
@@ -64,7 +64,7 @@ async def sign_typed_data(
         ctx, msg.primary_type, msg.metamask_v4_compat
     )
 
-    node = keychain.derive(msg.address_n)
+    node = keychain.derive(msg.address_n, force_strict=False)
     signature = secp256k1.sign(
         node.private_key(), data_hash, False, secp256k1.CANONICAL_SIG_ETHEREUM
     )

--- a/core/src/apps/ethereum/onekey/sign_typed_data_hash.py
+++ b/core/src/apps/ethereum/onekey/sign_typed_data_hash.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 async def sign_typed_data_hash(
     ctx: Context, msg: EthereumSignTypedHash, keychain: Keychain
 ) -> EthereumTypedDataSignature:
-    await paths.validate_path(ctx, keychain, msg.address_n)
+    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=False)
 
     if msg.chain_id:
         network = networks.by_chain_id(msg.chain_id)
@@ -46,7 +46,7 @@ async def sign_typed_data_hash(
 
     await confirm_typed_hash_final(ctx)
 
-    node = keychain.derive(msg.address_n)
+    node = keychain.derive(msg.address_n, force_strict=False)
     signature = secp256k1.sign(
         node.private_key(), data_hash, False, secp256k1.CANONICAL_SIG_ETHEREUM
     )

--- a/core/src/apps/ethereum/sign_message.py
+++ b/core/src/apps/ethereum/sign_message.py
@@ -36,9 +36,9 @@ async def sign_message(
     ctx: Context, msg: EthereumSignMessage, keychain: Keychain, defs: Definitions
 ) -> EthereumMessageSignature:
     validate_message(msg.message)
-    await paths.validate_path(ctx, keychain, msg.address_n)
+    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=False)
 
-    node = keychain.derive(msg.address_n)
+    node = keychain.derive(msg.address_n, force_strict=False)
     address = address_from_bytes(node.ethereum_pubkeyhash())
 
     network = defs.network

--- a/core/src/apps/ethereum/sign_tx.py
+++ b/core/src/apps/ethereum/sign_tx.py
@@ -43,7 +43,7 @@ async def sign_tx(
     ctx: wire.Context, msg: EthereumSignTx, keychain: Keychain, defs: Definitions
 ) -> EthereumTxRequest:
     check(msg)
-    await paths.validate_path(ctx, keychain, msg.address_n)
+    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=False)
 
     # Handle ERC20s
     token, address_bytes, recipient, value = await handle_erc20(ctx, msg)
@@ -76,7 +76,7 @@ async def sign_tx(
         if token is None and token_id is None and msg.data_length > 0:
             has_raw_data = True
             # await require_confirm_data(ctx, msg.data_initial_chunk, data_total)
-        node = keychain.derive(msg.address_n)
+        node = keychain.derive(msg.address_n, force_strict=False)
         recipient_str = address_from_bytes(recipient, network)
         from_str = address_from_bytes(from_addr or node.ethereum_pubkeyhash(), network)
         await require_confirm_fee(
@@ -245,7 +245,7 @@ async def send_request_chunk(ctx: wire.Context, data_left: int) -> EthereumTxAck
 def sign_digest(
     msg: EthereumSignTx, keychain: Keychain, digest: bytes
 ) -> EthereumTxRequest:
-    node = keychain.derive(msg.address_n)
+    node = keychain.derive(msg.address_n, force_strict=False)
     signature = secp256k1.sign(
         node.private_key(), digest, False, secp256k1.CANONICAL_SIG_ETHEREUM
     )

--- a/core/src/apps/ethereum/sign_tx_eip1559.py
+++ b/core/src/apps/ethereum/sign_tx_eip1559.py
@@ -66,7 +66,7 @@ async def sign_tx_eip1559(
 ) -> EthereumTxRequest:
     check(msg)
 
-    await paths.validate_path(ctx, keychain, msg.address_n)
+    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=False)
 
     # Handle ERC20s
     token, address_bytes, recipient, value = await handle_erc20(ctx, msg)
@@ -97,7 +97,7 @@ async def sign_tx_eip1559(
         if token is None and token_id is None and msg.data_length > 0:
             has_raw_data = True
             # await require_confirm_data(ctx, msg.data_initial_chunk, data_total)
-        node = keychain.derive(msg.address_n)
+        node = keychain.derive(msg.address_n, force_strict=False)
 
         recipient_str = address_from_bytes(recipient, network)
         from_str = address_from_bytes(from_addr or node.ethereum_pubkeyhash(), network)
@@ -189,7 +189,7 @@ def get_total_length(msg: EthereumSignTxEIP1559, data_total: int) -> int:
 def sign_digest(
     msg: EthereumSignTxEIP1559, keychain: Keychain, digest: bytes
 ) -> EthereumTxRequest:
-    node = keychain.derive(msg.address_n)
+    node = keychain.derive(msg.address_n, force_strict=False)
     signature = secp256k1.sign(
         node.private_key(), digest, False, secp256k1.CANONICAL_SIG_ETHEREUM
     )

--- a/core/src/apps/ethereum/sign_typed_data.py
+++ b/core/src/apps/ethereum/sign_typed_data.py
@@ -60,7 +60,7 @@ HIGH_RISK_PRIMARY_TYPES_ORDER = (
 async def sign_typed_data(
     ctx: Context, msg: EthereumSignTypedData, keychain: Keychain, defs: Definitions
 ) -> EthereumTypedDataSignature:
-    await paths.validate_path(ctx, keychain, msg.address_n)
+    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=False)
 
     network = defs.network
     ctx.primary_color, ctx.icon_path = get_color_and_icon(
@@ -71,7 +71,7 @@ async def sign_typed_data(
         ctx, msg.primary_type, msg.metamask_v4_compat
     )
 
-    node = keychain.derive(msg.address_n)
+    node = keychain.derive(msg.address_n, force_strict=False)
     signature = secp256k1.sign(
         node.private_key(), data_hash, False, secp256k1.CANONICAL_SIG_ETHEREUM
     )

--- a/core/src/apps/ethereum/sign_typed_data_hash.py
+++ b/core/src/apps/ethereum/sign_typed_data_hash.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 async def sign_typed_data_hash(
     ctx: Context, msg: EthereumSignTypedHash, keychain: Keychain, defs: Definitions
 ) -> EthereumTypedDataSignature:
-    await paths.validate_path(ctx, keychain, msg.address_n)
+    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=False)
 
     network = defs.network
     ctx.primary_color, ctx.icon_path = get_color_and_icon(
@@ -37,7 +37,7 @@ async def sign_typed_data_hash(
 
     await confirm_typed_hash_final(ctx)
 
-    node = keychain.derive(msg.address_n)
+    node = keychain.derive(msg.address_n, force_strict=False)
     signature = secp256k1.sign(
         node.private_key(), data_hash, False, secp256k1.CANONICAL_SIG_ETHEREUM
     )

--- a/core/src/apps/kaspa/get_address.py
+++ b/core/src/apps/kaspa/get_address.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 async def get_address(
     ctx: Context, msg: KaspaGetAddress, keychain: Keychain
 ) -> KaspaAddress:
-    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=True)
+    await paths.validate_path(ctx, keychain, msg.address_n)
 
     if not Prefix.is_valid(msg.prefix):
         raise wire.DataError("Invalid prefix provided.")

--- a/core/src/apps/kaspa/sign_tx.py
+++ b/core/src/apps/kaspa/sign_tx.py
@@ -63,7 +63,7 @@ async def sign_tx(
 
 
 async def sign_input(ctx, msg: Signable, keychain) -> bytes:
-    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=True)
+    await paths.validate_path(ctx, keychain, msg.address_n)
     node = keychain.derive(msg.address_n)
     hasher = hashwriter()
     hasher.write(msg.raw_message)

--- a/core/src/apps/nervos/get_address.py
+++ b/core/src/apps/nervos/get_address.py
@@ -100,7 +100,7 @@ async def get_address(
 
     if msg.network not in ["ckb", "ckt"]:
         raise ValueError(f"Invalid network: {msg.network}")
-    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=True)
+    await paths.validate_path(ctx, keychain, msg.address_n)
     node = keychain.derive(msg.address_n)
     address = generate_ckb_short_address(node, network=msg.network)
     if msg.show_display:

--- a/core/src/apps/nervos/sign_tx.py
+++ b/core/src/apps/nervos/sign_tx.py
@@ -26,7 +26,7 @@ async def sign_tx(
 ) -> NervosSignedTx:
     if msg.network not in ["ckb", "ckt"]:
         raise ValueError(f"Invalid network: {msg.network}")
-    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=True)
+    await paths.validate_path(ctx, keychain, msg.address_n)
 
     ctx.primary_color, ctx.icon_path = lv.color_hex(PRIMARY_COLOR), ICON
     node = keychain.derive(msg.address_n)

--- a/core/src/apps/nexa/get_address.py
+++ b/core/src/apps/nexa/get_address.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 async def get_address(
     ctx: Context, msg: NexaGetAddress, keychain: Keychain
 ) -> NexaAddress:
-    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=True)
+    await paths.validate_path(ctx, keychain, msg.address_n)
 
     if not Prefix.is_valid(msg.prefix):
         raise wire.DataError("Invalid prefix provided.")

--- a/core/src/apps/nexa/sign_tx.py
+++ b/core/src/apps/nexa/sign_tx.py
@@ -59,7 +59,7 @@ async def sign_tx(
 
 
 async def sign_input(ctx, msg: Signable, keychain) -> bytes:
-    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=True)
+    await paths.validate_path(ctx, keychain, msg.address_n)
     node = keychain.derive(msg.address_n)
 
     address = encode_address(node, prefix=address_prefix)

--- a/core/src/apps/nostr/get_public_key.py
+++ b/core/src/apps/nostr/get_public_key.py
@@ -24,7 +24,7 @@ async def get_public_key(
     ctx: Context, msg: NostrGetPublicKey, keychain: Keychain
 ) -> NostrPublicKey:
 
-    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=True)
+    await paths.validate_path(ctx, keychain, msg.address_n)
 
     node = keychain.derive(msg.address_n)
     pubkey = hexlify(node.public_key()[1:33]).decode()

--- a/core/src/apps/nostr/schnorr.py
+++ b/core/src/apps/nostr/schnorr.py
@@ -17,7 +17,7 @@ from . import ICON, PRIMARY_COLOR
 async def schnorr(
     ctx: wire.Context, msg: NostrSignSchnorr, keychain: Keychain
 ) -> NostrSignedSchnorr:
-    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=True)
+    await paths.validate_path(ctx, keychain, msg.address_n)
 
     node = keychain.derive(msg.address_n)
     convertedbits = bech32.convertbits(node.public_key()[1:33], 8, 5)

--- a/core/src/apps/polkadot/sign_tx.py
+++ b/core/src/apps/polkadot/sign_tx.py
@@ -12,7 +12,7 @@ from . import helper, seed, transaction
 async def sign_tx(
     ctx: wire.Context, msg: PolkadotSignTx, keychain: seed.Keychain
 ) -> PolkadotSignedTx:
-    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=True)
+    await paths.validate_path(ctx, keychain, msg.address_n)
 
     node = keychain.derive(msg.address_n)
     if utils.USE_THD89:

--- a/core/src/apps/starcoin/get_address.py
+++ b/core/src/apps/starcoin/get_address.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 async def get_address(
     ctx: Context, msg: StarcoinGetAddress, keychain: Keychain
 ) -> StarcoinAddress:
-    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=True)
+    await paths.validate_path(ctx, keychain, msg.address_n)
 
     node = keychain.derive(msg.address_n)
     public_key = node.public_key()[1:]

--- a/core/src/apps/starcoin/get_public_key.py
+++ b/core/src/apps/starcoin/get_public_key.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 async def get_public_key(
     ctx: Context, msg: StarcoinGetPublicKey, keychain: Keychain
 ) -> StarcoinPublicKey:
-    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=True)
+    await paths.validate_path(ctx, keychain, msg.address_n)
     node = keychain.derive(msg.address_n)
     pubkey = node.public_key()[1:]
 

--- a/core/src/apps/starcoin/sign_message.py
+++ b/core/src/apps/starcoin/sign_message.py
@@ -21,7 +21,7 @@ from .helper import (
 async def sign_message(
     ctx: wire.Context, msg: StarcoinSignMessage, keychain: Keychain
 ) -> StarcoinMessageSignature:
-    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=True)
+    await paths.validate_path(ctx, keychain, msg.address_n)
 
     node = keychain.derive(msg.address_n)
     pubkey = node.public_key()[1:]

--- a/core/src/apps/starcoin/sign_tx.py
+++ b/core/src/apps/starcoin/sign_tx.py
@@ -16,7 +16,7 @@ async def sign_tx(
     ctx: wire.Context, msg: StarcoinSignTx, keychain: Keychain
 ) -> StarcoinSignedTx:
 
-    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=True)
+    await paths.validate_path(ctx, keychain, msg.address_n)
 
     node = keychain.derive(msg.address_n)
     pubkey = node.public_key()[1:]

--- a/core/src/apps/sui/get_address.py
+++ b/core/src/apps/sui/get_address.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 async def get_address(
     ctx: Context, msg: SuiGetAddress, keychain: Keychain
 ) -> SuiAddress:
-    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=True)
+    await paths.validate_path(ctx, keychain, msg.address_n)
     ctx.primary_color, ctx.icon_path = lv.color_hex(PRIMARY_COLOR), ICON
     node = keychain.derive(msg.address_n)
     pub_key_bytes = seed.remove_ed25519_prefix(node.public_key())

--- a/core/src/apps/sui/sign_message.py
+++ b/core/src/apps/sui/sign_message.py
@@ -17,7 +17,7 @@ async def sign_message(
     ctx: wire.Context, msg: SuiSignMessage, keychain: Keychain
 ) -> SuiMessageSignature:
 
-    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=True)
+    await paths.validate_path(ctx, keychain, msg.address_n)
 
     node = keychain.derive(msg.address_n)
     pub_key_bytes = seed.remove_ed25519_prefix(node.public_key())

--- a/core/src/apps/sui/sign_tx.py
+++ b/core/src/apps/sui/sign_tx.py
@@ -14,7 +14,7 @@ from .helper import INTENT_BYTES, sui_address_from_pubkey
 @auto_keychain(__name__)
 async def sign_tx(ctx: wire.Context, msg: SuiSignTx, keychain: Keychain) -> SuiSignedTx:
 
-    await paths.validate_path(ctx, keychain, msg.address_n, force_strict=True)
+    await paths.validate_path(ctx, keychain, msg.address_n)
 
     node = keychain.derive(msg.address_n)
     pub_key_bytes = seed.remove_ed25519_prefix(node.public_key())


### PR DESCRIPTION
… to skip path detection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Based on the comprehensive review of the changes, here are the release notes:

- **Path Validation**
	- Modified path validation behavior across multiple blockchain applications
	- Reduced strictness in path validation for various cryptocurrency and blockchain signing operations

- **Keychain Management**
	- Updated default behavior for key derivation and path verification
	- Introduced more flexible validation parameters in key management processes

- **Supported Blockchains**
	- Changes impact applications for Aptos, Ethereum, Kaspa, Nervos, Nexa, Nostr, Polkadot, Starcoin, Sui, and other blockchain platforms

- **Key Changes**
	- Removed `force_strict=True` from multiple validation and derivation method calls
	- Allows for more lenient path and key validation across different blockchain signing scenarios

The modifications suggest a broader strategy to provide more flexible path validation while maintaining core security mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->