### PR TITLE
ci: lock build env to ubuntu 22.04

### DIFF
--- a/.github/workflows/build-static.yml
+++ b/.github/workflows/build-static.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-static:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the build infrastructure to use a fixed, stable operating system version for improved compatibility and reliability during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->