### PR TITLE
fix(core): remove `address_index` position limit in derivation path

### DIFF
--- a/core/src/apps/common/paths.py
+++ b/core/src/apps/common/paths.py
@@ -87,7 +87,7 @@ class PathSchema:
     REPLACEMENTS = {
         "account": "0-2147483647",  # origin "0-100"
         "change": "0,1",
-        "address_index": "0-1000000",
+        "address_index": "0-2147483647",  # origin "0-1000000"
     }
 
     WILDCARD_RANGES = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded the allowed range for address values, increasing the upper limit from 1,000,000 to 2,147,483,647 to support a broader set of inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->