### PR TITLE
feat(core): add support for tron cancel unstake

### DIFF
--- a/common/protob/messages-tron.proto
+++ b/common/protob/messages-tron.proto
@@ -105,7 +105,8 @@ message TronSignTx {
             optional uint64 balance = 3;
             optional string receiver_address = 4;
         }
-
+        message TronCancelAllUnfreezeV2Contract {
+        }
         // Vote Witness Contract
         message TronVoteWitnessContract {
             message Vote {
@@ -126,6 +127,7 @@ message TronSignTx {
         optional TronWithdrawExpireUnfreezeContract withdraw_expire_unfreeze_contract = 56;
         optional TronDelegateResourceContract delegate_resource_contract = 57;
         optional TronUnDelegateResourceContract undelegate_resource_contract = 58;
+        optional TronCancelAllUnfreezeV2Contract cancel_all_unfreeze_v2_contract = 59;
         optional bytes provider = 3;
         optional bytes contract_name = 5;
         optional uint32 permission_id = 6;

--- a/core/embed/extmod/modtrezorio/modtrezorio-camera.h
+++ b/core/embed/extmod/modtrezorio/modtrezorio-camera.h
@@ -32,7 +32,7 @@ STATIC mp_obj_t mod_trezorio_camera_scan_qrcode(mp_obj_t x, mp_obj_t y) {
   uint32_t pos_x = trezor_obj_get_uint(x);
   uint32_t pos_y = trezor_obj_get_uint(y);
 
-  uint8_t qr_code[512] = {0};
+  uint8_t qr_code[1024] = {0};
 
   uint32_t qr_len;
 

--- a/core/src/apps/tron/layout.py
+++ b/core/src/apps/tron/layout.py
@@ -235,6 +235,15 @@ def require_confirm_undelegate(
     )
 
 
+def require_confirm_cancel_all_unfreeze_v2(
+    ctx: Context,
+    signer: str,
+) -> Awaitable[None]:
+    from trezor.ui.layouts.lvgl import confirm_tron_unfreeze
+
+    return confirm_tron_unfreeze(ctx, "Cancel All UnStaking", signer, None, None)
+
+
 def require_confirm_vote_witness(
     ctx: Context,
     signer: str,

--- a/core/src/apps/tron/serialize.py
+++ b/core/src/apps/tron/serialize.py
@@ -214,6 +214,11 @@ def pack_contract(contract, owner_address):
             cmessage,
             base58.decode_check(contract.undelegate_resource_contract.receiver_address),
         )
+    elif contract.cancel_all_unfreeze_v2_contract:
+        write_varint(retc, 59)
+        api = "CancelAllUnfreezeV2Contract"
+        add_field(cmessage, 1, TYPE_LEN)
+        write_bytes_with_length(cmessage, base58.decode_check(owner_address))
     else:
         raise ValueError("Invalid contract type")
 

--- a/core/src/apps/tron/sign_tx.py
+++ b/core/src/apps/tron/sign_tx.py
@@ -179,6 +179,11 @@ async def _require_confirm_by_type(ctx, transaction, owner_address):
             contract.undelegate_resource_contract.receiver_address,
             None,
         )
+    elif contract.cancel_all_unfreeze_v2_contract:
+        await layout.require_confirm_cancel_all_unfreeze_v2(
+            ctx,
+            owner_address,
+        )
     elif contract.vote_witness_contract:
         vote_contract = contract.vote_witness_contract
         await layout.require_confirm_vote_witness(

--- a/core/src/trezor/lvglui/scrs/template.py
+++ b/core/src/trezor/lvglui/scrs/template.py
@@ -4320,45 +4320,47 @@ class TronAssetFreeze(FullSizeWindow):
             sender,
         )
         self.group_directions.add_dummy()
-
-        self.group_more = ContainerFlexCol(
-            self.container, None, padding_row=0, no_align=True
-        )
-        self.item_group_header = CardHeader(
-            self.group_more, _(i18n_keys.FORM__MORE), "A:/res/group-icon-more.png"
-        )
-        if resource is not None:
-            self.item_body_resource = DisplayItem(
-                self.group_more, _(i18n_keys.LIST_KEY__RESOURCE_COLON), resource
+        if any((resource, balance, receiver, duration, lock)):
+            self.group_more = ContainerFlexCol(
+                self.container, None, padding_row=0, no_align=True
             )
-        if balance:
-            if is_freeze:
-                self.item_body_freeze_balance = DisplayItem(
-                    self.group_more,
-                    _(i18n_keys.LIST_KEY__FROZEN_BALANCE_COLON),
-                    balance,
+            self.item_group_header = CardHeader(
+                self.group_more, _(i18n_keys.FORM__MORE), "A:/res/group-icon-more.png"
+            )
+            if resource is not None:
+                self.item_body_resource = DisplayItem(
+                    self.group_more, _(i18n_keys.LIST_KEY__RESOURCE_COLON), resource
                 )
-            else:
-                self.item_body_balance = DisplayItem(
+            if balance:
+                if is_freeze:
+                    self.item_body_freeze_balance = DisplayItem(
+                        self.group_more,
+                        _(i18n_keys.LIST_KEY__FROZEN_BALANCE_COLON),
+                        balance,
+                    )
+                else:
+                    self.item_body_balance = DisplayItem(
+                        self.group_more,
+                        _(i18n_keys.LIST_KEY__AMOUNT__COLON),
+                        balance,
+                    )
+            if duration:
+                self.item_body_duration = DisplayItem(
                     self.group_more,
-                    _(i18n_keys.LIST_KEY__AMOUNT__COLON),
-                    balance,
+                    _(i18n_keys.LIST_KEY__FROZEN_DURATION_COLON),
+                    duration,
                 )
-        if duration:
-            self.item_body_duration = DisplayItem(
-                self.group_more,
-                _(i18n_keys.LIST_KEY__FROZEN_DURATION_COLON),
-                duration,
-            )
-        if receiver is not None:
-            self.item_body_receiver = DisplayItem(
-                self.group_more, _(i18n_keys.LIST_KEY__RECEIVER_ADDRESS_COLON), receiver
-            )
-        if lock is not None:
-            self.item_body_lock = DisplayItem(
-                self.group_more, _(i18n_keys.LIST_KEY__LOCK_COLON), lock
-            )
-        self.group_more.add_dummy()
+            if receiver is not None:
+                self.item_body_receiver = DisplayItem(
+                    self.group_more,
+                    _(i18n_keys.LIST_KEY__RECEIVER_ADDRESS_COLON),
+                    receiver,
+                )
+            if lock is not None:
+                self.item_body_lock = DisplayItem(
+                    self.group_more, _(i18n_keys.LIST_KEY__LOCK_COLON), lock
+                )
+            self.group_more.add_dummy()
 
 
 class TronVoteWitness(FullSizeWindow):

--- a/core/src/trezor/messages.py
+++ b/core/src/trezor/messages.py
@@ -9286,6 +9286,7 @@ if TYPE_CHECKING:
         withdraw_expire_unfreeze_contract: "TronWithdrawExpireUnfreezeContract | None"
         delegate_resource_contract: "TronDelegateResourceContract | None"
         undelegate_resource_contract: "TronUnDelegateResourceContract | None"
+        cancel_all_unfreeze_v2_contract: "TronCancelAllUnfreezeV2Contract | None"
         provider: "bytes | None"
         contract_name: "bytes | None"
         permission_id: "int | None"
@@ -9304,6 +9305,7 @@ if TYPE_CHECKING:
             withdraw_expire_unfreeze_contract: "TronWithdrawExpireUnfreezeContract | None" = None,
             delegate_resource_contract: "TronDelegateResourceContract | None" = None,
             undelegate_resource_contract: "TronUnDelegateResourceContract | None" = None,
+            cancel_all_unfreeze_v2_contract: "TronCancelAllUnfreezeV2Contract | None" = None,
             provider: "bytes | None" = None,
             contract_name: "bytes | None" = None,
             permission_id: "int | None" = None,
@@ -9476,6 +9478,12 @@ if TYPE_CHECKING:
 
         @classmethod
         def is_type_of(cls, msg: Any) -> TypeGuard["TronUnDelegateResourceContract"]:
+            return isinstance(msg, cls)
+
+    class TronCancelAllUnfreezeV2Contract(protobuf.MessageType):
+
+        @classmethod
+        def is_type_of(cls, msg: Any) -> TypeGuard["TronCancelAllUnfreezeV2Contract"]:
             return isinstance(msg, cls)
 
     class TronVoteWitnessContract(protobuf.MessageType):

--- a/core/src/trezor/qr.py
+++ b/core/src/trezor/qr.py
@@ -214,7 +214,14 @@ def scan_qr(callback_obj):
                 camera.stop()
                 # await qr_task.callback_finish()
                 break
-            qr_data = camera.scan_qrcode(80, 180)
+            try:
+                qr_data = camera.scan_qrcode(80, 180)
+            except Exception as e:
+                if __debug__:
+                    print(f"scan qrcode error: {e}")
+                await callback_obj.error_feedback()
+                await loop.sleep(100)
+                continue
             if qr_data:
                 if __debug__:
                     print(qr_data.decode("utf-8"))

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -11499,6 +11499,7 @@ class TronContract(protobuf.MessageType):
         56: protobuf.Field("withdraw_expire_unfreeze_contract", "TronWithdrawExpireUnfreezeContract", repeated=False, required=False),
         57: protobuf.Field("delegate_resource_contract", "TronDelegateResourceContract", repeated=False, required=False),
         58: protobuf.Field("undelegate_resource_contract", "TronUnDelegateResourceContract", repeated=False, required=False),
+        59: protobuf.Field("cancel_all_unfreeze_v2_contract", "TronCancelAllUnfreezeV2Contract", repeated=False, required=False),
         3: protobuf.Field("provider", "bytes", repeated=False, required=False),
         5: protobuf.Field("contract_name", "bytes", repeated=False, required=False),
         6: protobuf.Field("permission_id", "uint32", repeated=False, required=False),
@@ -11518,6 +11519,7 @@ class TronContract(protobuf.MessageType):
         withdraw_expire_unfreeze_contract: Optional["TronWithdrawExpireUnfreezeContract"] = None,
         delegate_resource_contract: Optional["TronDelegateResourceContract"] = None,
         undelegate_resource_contract: Optional["TronUnDelegateResourceContract"] = None,
+        cancel_all_unfreeze_v2_contract: Optional["TronCancelAllUnfreezeV2Contract"] = None,
         provider: Optional["bytes"] = None,
         contract_name: Optional["bytes"] = None,
         permission_id: Optional["int"] = None,
@@ -11533,6 +11535,7 @@ class TronContract(protobuf.MessageType):
         self.withdraw_expire_unfreeze_contract = withdraw_expire_unfreeze_contract
         self.delegate_resource_contract = delegate_resource_contract
         self.undelegate_resource_contract = undelegate_resource_contract
+        self.cancel_all_unfreeze_v2_contract = cancel_all_unfreeze_v2_contract
         self.provider = provider
         self.contract_name = contract_name
         self.permission_id = permission_id
@@ -11714,6 +11717,10 @@ class TronUnDelegateResourceContract(protobuf.MessageType):
         self.resource = resource
         self.balance = balance
         self.receiver_address = receiver_address
+
+
+class TronCancelAllUnfreezeV2Contract(protobuf.MessageType):
+    MESSAGE_WIRE_TYPE = None
 
 
 class TronVoteWitnessContract(protobuf.MessageType):


### PR DESCRIPTION
1. increase the size of qr code decode buffer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new option to cancel all unfreeze operations in Tron transactions with an updated confirmation process.
  - Enhanced QR code scanning to support larger codes and include improved error recovery for a smoother experience.
  - Streamlined the asset freeze interface so that additional transaction details are shown only when relevant, resulting in a cleaner display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->