### PR TITLE
adjust page destroy time

### DIFF
--- a/core/src/trezor/lvglui/scrs/common.py
+++ b/core/src/trezor/lvglui/scrs/common.py
@@ -552,7 +552,7 @@ class FullSizeWindow(lv.obj):
         def read_content(self) -> list[str]:
             return [self.layout_title or ""] + [self.layout_subtitle or ""]
 
-    def destroy(self, delay_ms=250):
+    def destroy(self, delay_ms=400):
         try:
             self.del_delayed(delay_ms)
         except Exception:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Increased the default delay before certain windows are closed, resulting in a slightly longer visible transition when closing full-size windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->