### PR TITLE
fix: turbo text style

### DIFF
--- a/core/src/apps/ethereum/onekey/sign_tx.py
+++ b/core/src/apps/ethereum/onekey/sign_tx.py
@@ -88,7 +88,9 @@ async def sign_tx(
 
         from trezor.ui.layouts.lvgl import confirm_turbo
 
-        await confirm_turbo(ctx, (_(i18n_keys.LIST_VALUE__SEND) + suffix), network.name)
+        await confirm_turbo(
+            ctx, (_(i18n_keys.LIST_VALUE__SEND) + " " + suffix), network.name
+        )
     else:
         show_details = await require_show_overview(
             ctx,

--- a/core/src/apps/ethereum/onekey/sign_tx_eip1559.py
+++ b/core/src/apps/ethereum/onekey/sign_tx_eip1559.py
@@ -110,7 +110,9 @@ async def sign_tx_eip1559(
 
         from trezor.ui.layouts.lvgl import confirm_turbo
 
-        await confirm_turbo(ctx, (_(i18n_keys.LIST_VALUE__SEND) + suffix), network.name)
+        await confirm_turbo(
+            ctx, (_(i18n_keys.LIST_VALUE__SEND) + " " + suffix), network.name
+        )
     else:
         show_details = await require_show_overview(
             ctx,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved formatting of confirmation prompt text in turbo mode by adding a space between the "Send" label and the suffix (e.g., "Send NFT" instead of "SendNFT") for a clearer display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->