### PR TITLE
fix: attach to pin for btc-only build

### DIFF
--- a/common/protob/messages.proto
+++ b/common/protob/messages.proto
@@ -605,9 +605,9 @@ enum MessageType {
     MessageType_FileInfoList = 10024 [(wire_out) = true];
     MessageType_OnekeyGetFeatures = 10025 [(bitcoin_only) = true,(wire_in) = true];
     MessageType_OnekeyFeatures = 10026 [(bitcoin_only) = true,(wire_out) = true];
-    MessageType_WriteSEPrivateKey = 10027 [(wire_in) = true, (wire_bootloader) = true];
-    MessageType_GetPassphraseState = 10028 [(wire_in) = true];
-    MessageType_PassphraseState = 10029 [(wire_out) = true];
+    MessageType_WriteSEPrivateKey = 10027 [(bitcoin_only) = true,(wire_in) = true, (wire_bootloader) = true];
+    MessageType_GetPassphraseState = 10028 [(bitcoin_only) = true,(wire_in) = true];
+    MessageType_PassphraseState = 10029 [(bitcoin_only) = true,(wire_out) = true];
     MessageType_UnLockDevice = 10030 [(bitcoin_only) = true, (wire_in) = true];
     MessageType_UnLockDeviceResponse = 10031 [(bitcoin_only) = true, (wire_out) = true];
  }

--- a/common/protob/messages.proto
+++ b/common/protob/messages.proto
@@ -605,7 +605,7 @@ enum MessageType {
     MessageType_FileInfoList = 10024 [(wire_out) = true];
     MessageType_OnekeyGetFeatures = 10025 [(bitcoin_only) = true,(wire_in) = true];
     MessageType_OnekeyFeatures = 10026 [(bitcoin_only) = true,(wire_out) = true];
-    MessageType_WriteSEPrivateKey = 10027 [(bitcoin_only) = true,(wire_in) = true, (wire_bootloader) = true];
+    MessageType_WriteSEPrivateKey = 10027 [(wire_in) = true, (wire_bootloader) = true];
     MessageType_GetPassphraseState = 10028 [(bitcoin_only) = true,(wire_in) = true];
     MessageType_PassphraseState = 10029 [(bitcoin_only) = true,(wire_out) = true];
     MessageType_UnLockDevice = 10030 [(bitcoin_only) = true, (wire_in) = true];

--- a/core/src/trezor/enums/MessageType.py
+++ b/core/src/trezor/enums/MessageType.py
@@ -104,6 +104,9 @@ ResourceUpdate = 10022
 ListResDir = 10023
 OnekeyGetFeatures = 10025
 OnekeyFeatures = 10026
+WriteSEPrivateKey = 10027
+GetPassphraseState = 10028
+PassphraseState = 10029
 UnLockDevice = 10030
 UnLockDeviceResponse = 10031
 if not utils.BITCOIN_ONLY:
@@ -424,6 +427,3 @@ if not utils.BITCOIN_ONLY:
     ResourceRequest = 10020
     ResourceAck = 10021
     FileInfoList = 10024
-    WriteSEPrivateKey = 10027
-    GetPassphraseState = 10028
-    PassphraseState = 10029

--- a/core/src/trezor/enums/MessageType.py
+++ b/core/src/trezor/enums/MessageType.py
@@ -104,7 +104,6 @@ ResourceUpdate = 10022
 ListResDir = 10023
 OnekeyGetFeatures = 10025
 OnekeyFeatures = 10026
-WriteSEPrivateKey = 10027
 GetPassphraseState = 10028
 PassphraseState = 10029
 UnLockDevice = 10030
@@ -427,3 +426,4 @@ if not utils.BITCOIN_ONLY:
     ResourceRequest = 10020
     ResourceAck = 10021
     FileInfoList = 10024
+    WriteSEPrivateKey = 10027


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for new Bitcoin-only message types: GetPassphraseState and PassphraseState.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->