### PR TITLE
fix(core): propagate SE failure when importing mnemonic

### DIFF
--- a/core/src/storage/device.py
+++ b/core/src/storage/device.py
@@ -1131,9 +1131,13 @@ def store_mnemonic_secret(
         common.set_bool(_NAMESPACE, INITIALIZED, True, public=True)
     else:
         if backup_type == BackupType.Bip39:
-            config.se_import_mnemonic(secret)
+            if not config.se_import_mnemonic(secret):
+                raise RuntimeError("Failed to import mnemonic into the secure element")
         else:
-            config.se_import_slip39(secret, backup_type, identifier, iteration_exponent)
+            if not config.se_import_slip39(
+                secret, backup_type, identifier, iteration_exponent
+            ):
+                raise RuntimeError("Failed to import secret into the secure element")
     common.set_uint8(_NAMESPACE, _BACKUP_TYPE, backup_type)
     common.set_true_or_delete(_NAMESPACE, _NO_BACKUP, no_backup)
     if not no_backup:


### PR DESCRIPTION
`store_mnemonic_secret()` drops the return value of `config.se_import_mnemonic()` and `config.se_import_slip39()` in core/src/storage/device.py. The SE layer does report failure: `se_set_mnemonic()` returns secfalse when the THD89 APDU exchange or MAC check fails, and the modtrezorconfig binding maps that to False. But the result is discarded, so `ResetDevice` still answers `Success("Initialized")` even when nothing was actually stored. The device then looks uninitialized after reboot, and with `no_backup` the seed is just lost.

This raises on failure instead, same behavior as the classic firmware (`config_setMnemonic` failure path in firmware-classic1s).

Only static analysis, I don't have hardware to force the SE fault, but the discarded return is straightforward.